### PR TITLE
fix: module_uppercase includes special characters

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -39,7 +39,8 @@ module.exports = yeoman.Base.extend({
 
       this.props = props;
       if(this.props.module) {
-          this.props.module_uppercase = _.upperCase(this.props.module);
+          var module_name = this.props.module;
+          this.props.module_uppercase = module_name.toUpperCase();
       }
       this.props.module_base = 'static/modules/';
 

--- a/generators/app/templates/_requirements.js
+++ b/generators/app/templates/_requirements.js
@@ -6,6 +6,6 @@ module.exports = [
     // eg 'modules/your_dependency/*.js'
 
     'modules/<%= module %>/*.js',
-    'modules/ap.payment.status/tests/mock/**/*.js',
-    'modules/ap.payment.status/tests/spec/**/*.js'
+    'modules/<%= module %>/tests/mock/**/*.js',
+    'modules/<%= module %>/tests/spec/**/*.js'
 ];


### PR DESCRIPTION
remove use of lodash's _.upperCase for vanilla .toUpperCase() to include special characters in module names
